### PR TITLE
Use cargo sparse registry in dev container

### DIFF
--- a/dev-env-as-code/Dockerfile
+++ b/dev-env-as-code/Dockerfile
@@ -13,8 +13,8 @@ RUN curl https://github.com/watchexec/cargo-watch/releases/download/v7.8.0/cargo
     && tar -xf cargo-watch.tar.xz \
     && mv cargo-watch-v7.8.0-x86_64-unknown-linux-musl/cargo-watch /home
 
-RUN cargo install --version 0.8.2 cornucopia 
-RUN cargo install cargo-chef --locked
+RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo install --version 0.8.2 cornucopia 
+RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo install cargo-chef --locked
 
 FROM rust:slim
 


### PR DESCRIPTION
For arm64 builds, cargo uses all available memory and often gets killed by the OS. Rust v1.68 has stable support for the sparse registry protocol, which uses much less memory.

Relates to https://github.com/purton-tech/rust-on-nails/issues/14

Additional articles:

- https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol
- https://yaleman.org/post/2022/2022-10-23-docker-rust-cargo-and-137-errors/
- https://users.rust-lang.org/t/cargo-uses-too-much-memory-being-run-in-qemu/76531