### PR TITLE
Prevent .git directory in crates/axum-server

### DIFF
--- a/rust-on-nails.com/content/docs/ide-setup/dev-env-as-code.md
+++ b/rust-on-nails.com/content/docs/ide-setup/dev-env-as-code.md
@@ -96,7 +96,7 @@ members = [
 Open up the terminal in VSCode again and run the following
 
 ```
-$ cargo new crates/axum-server
+$ cargo new --vcs=none crates/axum-server
      Created binary (application) `crates/axum-server` package
 ```
 


### PR DESCRIPTION
Running the command "cargo new crates/axum-server" will create crates/axum-server/.git as a side-effect. When we later run "git add ." we will see this message:

error: 'crates/axum-server/' does not have a commit checked out

Using the --vsc=none flag will omit the .git directory.