### PR TITLE
fix: Remove extra markdown code fence in docs

### DIFF
--- a/rust-on-nails.com/content/docs/database-part-1/database-access.md
+++ b/rust-on-nails.com/content/docs/database-part-1/database-access.md
@@ -231,6 +231,5 @@ running 1 test
     },
 ]
 
-```
 test tests::load_users ... ok
 ```


### PR DESCRIPTION
https://rust-on-nails.com/docs/database-part-1/database-access/ currently looks like this:

![Screen Shot 2023-03-11 at 12 20 26 PM](https://user-images.githubusercontent.com/33318/224502659-f4b47272-eeed-4d63-90c2-769212e76b95.png)
