### PR TITLE
Update dev-env-as-code.md

### DIFF
--- a/rust-on-nails.com/content/docs/ide-setup/dev-env-as-code.md
+++ b/rust-on-nails.com/content/docs/ide-setup/dev-env-as-code.md
@@ -109,13 +109,12 @@ You should now have a folder structure like the following.
 │         axum-server/
 │         │  └── main.rs
 │         └── Cargo.toml
-├── Cargo.toml
-└── Cargo.lock
+└── Cargo.toml
 ```
 
 ## Testing
 
-Test out you development environment with
+Test out your development environment with
 
 ```
 $ cargo run


### PR DESCRIPTION
removed cargo.lock from folder tree since this would not be seen until the code is built in the following step.