### PR TITLE
chore: fix typo on make directory parsel

### DIFF
--- a/rust-on-nails.com/content/docs/full-stack-web/asset-pipeline.md
+++ b/rust-on-nails.com/content/docs/full-stack-web/asset-pipeline.md
@@ -22,7 +22,7 @@ I've used [Parcel](https://parceljs.org/) on several projects and before that [W
 If you look at your `.devcontainer/docker-compose.yml` you'll see a line that is commented out.
 
 ```yml
-#- node_modules:/workspace/crates/asset-pipeline/node_modules # Set target as a volume for performance. 
+#- node_modules:/workspace/crates/asset-pipeline/node_modules # Set target as a volume for performance.
 ```
 
 Comment that back in and rebuild your devcontainer. This will setup the node_modules folder as a volume and you will get way better performance during builds. This is due to the fact the node_modules folder has many files and docker tries to sync them with your main file system.
@@ -48,7 +48,7 @@ node_modules
 To install parcel
 
 ```sh
-$ mdir crates/asset-pipeline
+$ mkdir crates/asset-pipeline
 $ cd crates/asset-pipeline
 $ npm install --save-dev parcel
 ```


### PR DESCRIPTION
## why

- [x] fix typo

![image](https://github.com/purton-tech/rust-on-nails/assets/70436490/94572a5e-4d9c-49bf-8a38-58c950ef613a)
