### PR TITLE
fix the insert operations on the database-migrations part

### DIFF
--- a/rust-on-nails.com/content/docs/database-part-1/database-migrations.md
+++ b/rust-on-nails.com/content/docs/database-part-1/database-migrations.md
@@ -35,9 +35,9 @@ CREATE TABLE users (
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
-INSERT INTO users(email, hashed_password) VALUES('test1@test1.com');
-INSERT INTO users(email, hashed_password) VALUES('test2@test1.com');
-INSERT INTO users(email, hashed_password) VALUES('test3@test1.com');
+INSERT INTO users(email) VALUES('test1@test1.com');
+INSERT INTO users(email) VALUES('test2@test1.com');
+INSERT INTO users(email) VALUES('test3@test1.com');
 
 -- migrate:down
 DROP TABLE users;

--- a/rust-on-nails.com/content/docs/database-part-1/database-migrations.md
+++ b/rust-on-nails.com/content/docs/database-part-1/database-migrations.md
@@ -73,7 +73,7 @@ And you should see
 ```sh
  count 
 -------
-      0
+      3
 (1 row)
 ```
 


### PR DESCRIPTION
Thanks for the awesome resource!

Since you changed the sql operations on [this commit](https://github.com/purton-tech/rust-on-nails/pull/67/commits/da9a2174a03df4b82d3d6406c7ea6f996232374b#diff-0256c8377ce51c069469a6b8b71bb539e8b9f10acaa29b1f18808b9c00a0840bL43-L45) at [this PR](https://github.com/purton-tech/rust-on-nails/pull/67#), you might forget to delete the non-existent column `hashed_password` for the insert operation.
In the current docs, `dbmate up` fails to execute.

## Screenshots

Current
![image](https://github.com/purton-tech/rust-on-nails/assets/50320710/362c9ab2-d2aa-4b9b-81a1-1df8cad51634)

Fixed
![image](https://github.com/purton-tech/rust-on-nails/assets/50320710/e49aee9d-9876-4a40-bf2d-25acab3d6bc1)

Sorry if this is intended.