### PR TITLE
Added POSTGRES_DATABASE to docker-compose.postgres.yml

### DIFF
--- a/.devcontainer/docker-compose.postgres.yml
+++ b/.devcontainer/docker-compose.postgres.yml
@@ -6,6 +6,7 @@ services:
     environment:
       POSTGRES_PASSWORD: testpassword
       POSTGRES_USER: postgres
+      POSTGRES_DATABASE: nails
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s


### PR DESCRIPTION
Without the POSTGRES_DATABASE environment variable, the database doesn't get created (though the default user/password do).  This causes dbmate migrations to fail, and the database commands in general to not function.