### PR TITLE
Added missing axum required features

### DIFF
--- a/rust-on-nails.com/content/docs/full-stack-web/web-server.md
+++ b/rust-on-nails.com/content/docs/full-stack-web/web-server.md
@@ -109,7 +109,7 @@ impl From<PoolError> for CustomError {
 Make sure you're in the `crates/web-server` folder and add Axum to your `Cargo.toml` using the following command.
 
 ```sh
-cargo add axum@0.7 --no-default-features -F json
+cargo add axum@0.7 --no-default-features -F json,http1,tokio
 cargo add tokio@1 --no-default-features -F macros,fs,rt-multi-thread
 cargo add --path ../db
 ```


### PR DESCRIPTION
Axum requires tokio and http1 (or http2 if you are forcing TLS) in order to serve pages.  Added to the feature list in the web-server.md doc