### PR TITLE
Fixed some typos in web-pages.md

### DIFF
--- a/rust-on-nails.com/content/docs/full-stack-web/web-pages.md
+++ b/rust-on-nails.com/content/docs/full-stack-web/web-pages.md
@@ -85,7 +85,7 @@ Create a file `crates/web-pages/src/users.rs`.
 ```rust
 use crate::layout::Layout;
 use db::User;
-use dioxus::prelue::*;
+use dioxus::prelude::*;
 use dioxus::prelude::component;
 
 // Define the properties for IndexPage
@@ -108,7 +108,7 @@ pub fn IndexPage(props: IndexPageProps) -> Element {
                     }
                 }
                 tbody {
-                    for user in users {
+                    for user in props.users {
                         tr {
                             td {
                                 strong {


### PR DESCRIPTION
Fixed two issues that was introduced in [this commit](https://github.com/purton-tech/rust-on-nails/commit/75fb89da0207bb487ea2145b8d814c5828cc3201)

Issue1: typo on `prelude`
Issue2: `users` was not in scope as the input param of function was changed.

Testing:
Tested in my local and after the fix, the `http://localhost:3000/` could be successfully rendered. 