### PR TITLE
Update deprecated extension in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
 				"mutantdino.resourcemonitor",
 				"matklad.rust-analyzer",
 				"tamasfe.even-better-toml",
-				"serayuzgur.crates"
+				"fill-labs.dependi"
 			]
 		}
 	},

--- a/nails-devcontainer/.devcontainer/devcontainer.json
+++ b/nails-devcontainer/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
 				"mutantdino.resourcemonitor",
 				"rust-lang.rust-analyzer",
 				"tamasfe.even-better-toml",
-				"serayuzgur.crates"
+				"fill-labs.dependi"
 			]
 		}
 	},


### PR DESCRIPTION
crates extension is deprecated
replace by dependi as suggested on the extension page