### PR TITLE
Updated workspace from resolver to edition.

### DIFF
--- a/crates/static-website/content/docs/ide-setup/dev-env-as-code/index.md
+++ b/crates/static-website/content/docs/ide-setup/dev-env-as-code/index.md
@@ -75,7 +75,7 @@ We are going to create a workspace for our web application. Create a new `Cargo.
 
 ```toml
 [workspace]
-resolver = "2"
+edition = "2021"
 
 members = [
     "crates/*",


### PR DESCRIPTION
Updated to edition for workspace because `resolver = "2"` is [now default](https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details). It looks nicer.