### PR TITLE
Update resolver to version 3 in documentation.

### DIFF
--- a/crates/static-website/content/docs/ide-setup/dev-env-as-code/index.md
+++ b/crates/static-website/content/docs/ide-setup/dev-env-as-code/index.md
@@ -75,7 +75,7 @@ We are going to create a workspace for our web application. Create a new `Cargo.
 
 ```toml
 [workspace]
-resolver = "2"
+resolver = "3"
 
 members = [
     "crates/*",


### PR DESCRIPTION
Why not use [resolver version 3](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/cargo-resolver.html)?