### PR TITLE
Make fully ARM64 compatible

### DIFF
--- a/crates/static-website/content/docs/full-stack-web/web-server/index.md
+++ b/crates/static-website/content/docs/full-stack-web/web-server/index.md
@@ -8,7 +8,7 @@ The functions that respond to routes can have parameters. These parameters which
 
 ## Handling Configuration
 
-We'll separate our configuration into it's own file. create `crates/web-server/src/config.rs`
+We'll separate our configuration into its own file. create `crates/web-server/src/config.rs`
 
 ```rust
 #[derive(Clone, Debug)]

--- a/crates/static-website/content/docs/full-stack-web/web-server/index.md
+++ b/crates/static-website/content/docs/full-stack-web/web-server/index.md
@@ -164,7 +164,7 @@ pub async fn loader(Extension(pool): Extension<db::Pool>) -> Result<Json<Vec<Use
 
 We could use `cargo run` to start our server but ideally we'd like our server to re-start when we make changes and for the browser to reload itself.
 
-We've installed [Just](https://github.com/casey/just) which is a command runner.
+Our development environment (container) comes preinstalled with [Just](https://github.com/casey/just) which is a command runner.
 
 Issue the following command to create a justfile with an entry to run our server.
 

--- a/crates/static-website/content/docs/full-stack-web/web-server/index.md
+++ b/crates/static-website/content/docs/full-stack-web/web-server/index.md
@@ -97,7 +97,7 @@ Make sure you're in the `crates/web-server` folder and add Axum to your `Cargo.t
 
 ```sh
 cargo add axum@0.7 --no-default-features -F json,http1,tokio
-cargo add axum-extra@0.9 --F form
+cargo add axum-extra@0.9 -F form
 cargo add tokio@1 --no-default-features -F macros,rt-multi-thread
 cargo add tokio-util@0.7 --no-default-features
 cargo add tower-livereload@0.9

--- a/dev-env-as-code/Dockerfile
+++ b/dev-env-as-code/Dockerfile
@@ -98,7 +98,6 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/* /var/cache/* \
-
     # Docker Engine for Earthly. https://docs.docker.com/engine/install/debian/
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
@@ -111,12 +110,10 @@ RUN apt-get update && \
     && apt-get -y update \
     && apt-get -y --no-install-recommends install docker-ce docker-ce-cli containerd.io \
     && apt-get autoremove -y && apt-get clean -y \
-
     # Tailwind binary + extra
     && curl -OL https://github.com/dobicinaitis/tailwind-cli-extra/releases/latest/download/tailwindcss-extra-linux-x64 \
     && chmod +x tailwindcss-extra-linux-x64 \
     && mv tailwindcss-extra-linux-x64 /usr/local/bin/tailwind-extra \
-
     # Create a non-root user
     && groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
@@ -131,14 +128,20 @@ RUN apt-get update && \
      # Database migrations   
     && curl -OL https://github.com/amacneil/dbmate/releases/download/v$DBMATE_VERSION/dbmate-linux-${TARGETARCH} \
     && mv ./dbmate-linux-${TARGETARCH} /usr/bin/dbmate \
-    && chmod +x /usr/bin/dbmate \
-    # Mold - Fast Rust Linker
-    && curl -OL https://github.com/rui314/mold/releases/download/v$MOLD_VERSION/mold-$MOLD_VERSION-x86_64-linux.tar.gz \
-    && tar -xf mold-$MOLD_VERSION-x86_64-linux.tar.gz \
-    && mv ./mold-$MOLD_VERSION-x86_64-linux/bin/mold /usr/bin/ \
-    && mv ./mold-$MOLD_VERSION-x86_64-linux/lib/mold/mold-wrapper.so /usr/bin/ \
-    && rm mold-$MOLD_VERSION-x86_64-linux.tar.gz \
-    && rm -rf ./mold-$MOLD_VERSION-x86_64-linux \
+    && chmod +x /usr/bin/dbmate
+
+# Mold - Fast Rust Linker
+RUN case "${TARGETARCH}" in \
+        amd64) ARCH="x86_64" ;; \
+        arm64) ARCH="aarch64" ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac \
+    && curl -OL https://github.com/rui314/mold/releases/download/v$MOLD_VERSION/mold-$MOLD_VERSION-${ARCH}-linux.tar.gz \
+    && tar -xf mold-$MOLD_VERSION-${ARCH}-linux.tar.gz \
+    && mv ./mold-$MOLD_VERSION-${ARCH}-linux/bin/mold /usr/bin/ \
+    && mv ./mold-$MOLD_VERSION-${ARCH}-linux/lib/mold/mold-wrapper.so /usr/bin/ \
+    && rm mold-$MOLD_VERSION-${ARCH}-linux.tar.gz \
+    && rm -rf ./mold-$MOLD_VERSION-${ARCH}-linux \
     && chmod +x /usr/bin/mold
 
 RUN wget https://github.com/earthly/earthly/releases/download/v$EARTHLY_VERSION/earthly-linux-${TARGETARCH} -O /usr/local/bin/earthly \


### PR DESCRIPTION
I noticed that as per #14 the `mold` installation step was still hard-coded for `x86_64` which obviously would not work on the ARM64 container. This pull request updates the Dockerfile to ensure that the correct platform is selected.